### PR TITLE
Drop `dvc pull` from sky-config.yaml

### DIFF
--- a/sky-config.yaml
+++ b/sky-config.yaml
@@ -16,6 +16,5 @@ setup: | # only executed on `sky launch`
   sudo add-apt-repository ppa:flexiondotorg/nvtop -y && sudo apt install nvtop
 run: | # executed on `sky launch` or `sky exec`
   cd ~/sky_workdir
-  dvc pull
   dvc exp run --pull --allow-missing
   dvc exp push origin


### PR DESCRIPTION
There was a bug with `--pull` and `--allow-missing` but I think (hope?) in latest DVC version you should not need to do the entire `dvc pull`